### PR TITLE
Quotation marks in frontmatter

### DIFF
--- a/content/draft.md
+++ b/content/draft.md
@@ -1,0 +1,12 @@
+---
+title: "draft"
+description: "you shouldn't be able to see this"
+draft: "true"
+---
+
+
+DRAFT
+
+IN PROGRESS
+
+

--- a/content/index.md
+++ b/content/index.md
@@ -7,7 +7,7 @@ description: This is Blaze, a ""simple"" static site generator written in Rust
 
 Blaze is a project that aims to convert a collection of Markdown files, specifically in the format preferred by [Obsidian](https://obsidian.md/), into a static website.
 
-Worked on by Ed and Ossac (maybe mace if he responds to my emails).
+Worked on by Ed and Ossac (and Reaper) (maybe mace if he responds to my emails).
 
 Officially releasing soon. See the [repository](https://github.com/EddieTheEd/Blaze) to find out on our progress!
 

--- a/content/plan.md
+++ b/content/plan.md
@@ -9,6 +9,7 @@ These are the current bugs that Blaze has:
 
 - Backlinks do not work when the filename of the thing being linked has spaces in it
 - Title frontmatter formatted like `title: "{{title}}"` will still have the quotation marks
+    - FIXED - Reaper
 
 ## The development plan
 

--- a/content/plan.md
+++ b/content/plan.md
@@ -54,3 +54,4 @@ The plan will be divided into these parts:
 *Focusing on performance*
 
 - Only modify files that are changed, i.e. don't delete all the html and replace, but change the html for files that are changed (wording???)
+    - Maybe check last date/time of modification? and store last cargo run/build date/time?

--- a/content/plan.md
+++ b/content/plan.md
@@ -8,7 +8,7 @@ description: The plan for Blaze's development
 These are the current bugs that Blaze has:
 
 - Backlinks do not work when the filename of the thing being linked has spaces in it
-- Title frontmatter formatted like `title: "{{title}}"` will still have the quotation marks
+- ~Title frontmatter formatted like `title: "{{title}}"` will still have the quotation marks~
     - FIXED - Reaper
 
 ## The development plan

--- a/content/testing.md
+++ b/content/testing.md
@@ -1,5 +1,5 @@
 ---
-title: Testing
+title: "Reaper's Testing"
 description: where things are tested
 ---
 
@@ -10,6 +10,7 @@ hello
 but also
 
 .md)
+- Is this how it is supposed to work? - T
 
 but [this link](index.md) is processed correctly...
 

--- a/content/testing.md
+++ b/content/testing.md
@@ -1,5 +1,5 @@
 ---
-title: ""Reaper's Testing""
+title: "Reaper's Testing"
 description: where things are tested
 ---
 

--- a/content/testing.md
+++ b/content/testing.md
@@ -1,5 +1,5 @@
 ---
-title: "Reaper's Testing"
+title: ""Reaper's Testing""
 description: where things are tested
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,7 +266,7 @@ fn compile_markdown (
 
                                         match key {
                                             "title" => {
-                                                let processed_title = val.trim().trim_matches('\'').trim_matches('\"').to_string();
+                                                let processed_title = val.trim().trim_matches('\'').trim_matches('\"').to_string(); // It unfortunately removes all quotation marks at the beginning and end of the title (First ', then ")
                                                 frontmatter.title = Some(processed_title);
                                             },
                                             "description" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,7 +337,7 @@ fn compile_markdown (
                                             backlinks_partials.push_str(
                                                 format!(r#"{{{{ partial "backlink.html" . ({}, {}, {}, {}) }}}}
 "#, 
-                                                    info.title,
+                                                    info.title.trim_matches('\'').trim_matches('\"').to_string(),
                                                     link.path,
                                                     info.description.clone().unwrap_or("".to_string()),
                                                     info.modified).as_str()

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use toml::Value;
 use markdown::{to_html_with_options, Constructs};
 use regex::Regex;
 
+
 #[derive(Deserialize, Debug)]
 struct Config {
     build: Build,
@@ -36,6 +37,9 @@ enum FsThing {
     File { path: String, content: String, metadata: Metadata },
     Directory { path: String, contents: Vec<FsThing>, metadata: Metadata }
 }
+
+// static mut drafts = Vec::<T>::new();
+
 
 // wrapper function to format a date
 fn format_date (time: u64) -> String {
@@ -261,8 +265,45 @@ fn compile_markdown (
                                         // dunno what unwrap_or does, so im just gonna replace lol
 
                                         match key {
-                                            "title" => frontmatter.title = Some(val.trim().to_string()),
-                                            "description" => frontmatter.description = Some(val.trim().to_string()),
+                                            "title" => {
+                                                let processed_title = val.trim().trim_matches('\'').trim_matches('\"').to_string();
+                                                frontmatter.title = Some(processed_title);
+                                            },
+                                            "description" => {
+                                                frontmatter.description = Some(val.trim().trim_matches('\"').to_string())
+                                            },
+                                            
+                                            // If draft: true, then don't compile
+                                            "draft" => {
+                                                if val.trim().trim_matches('\"') == "true" {
+                                                    println!("DRAFT {}", path);
+                                                    // Code to make it not compile
+                                                    let mut chars = val.chars();
+
+                                                    // Get the first character
+                                                    let first_char = chars.next(); // Returns an Option<char>
+                                                
+                                                    // Iterate to the last character
+                                                    let mut last_char = None;
+                                                    while let Some(c) = chars.next() {
+                                                        last_char = Some(c);
+                                                    }
+                                                    if first_char == "\'".chars().next() || first_char == "\'".chars().next() {
+                                                        if last_char == "\"".chars().next() || last_char == "\"".chars().next() {
+                                                            if first_char == last_char {
+                                                                let mut modified_string: String = chars.collect();
+                                                                // Remove the first character
+                                                                modified_string.remove(0);
+
+                                                                // Remove the last character
+                                                                modified_string.pop();
+                                                            }
+
+                                                            
+                                                        }
+                                                    }
+                                                }
+                                            },
                                             _ => (),
                                         }
                                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,33 +266,8 @@ fn compile_markdown (
 
                                         match key {
                                             "title" => {
-                                                let mut chars = val.chars();
-
-                                                // Get the first character
-                                                let first_char = chars.next(); // Returns an Option<char>
-                                            
-                                                // Iterate to the last character
-                                                let mut last_char = None;
-                                                while let Some(c) = chars.next() {
-                                                    last_char = Some(c);
-                                                }
-                                                if first_char == "\'".chars().next() || first_char == "\'".chars().next() {
-                                                    if last_char == "\"".chars().next() || last_char == "\"".chars().next() {
-                                                        if first_char == last_char {
-                                                            let mut modified_string: String = chars.collect();
-                                                            // Remove the first character
-                                                            modified_string.remove(0);
-
-                                                            // Remove the last character
-                                                            modified_string.pop();
-                                                            frontmatter.title = modified_string;
-                                                        }
-
-                                                        
-                                                    }
-                                                }
-                                               
-                                                
+                                                let processed_title = val.trim().trim_matches('\'').trim_matches('\"').to_string();
+                                                frontmatter.title = Some(processed_title);
                                             },
                                             "description" => {
                                                 frontmatter.description = Some(val.trim().trim_matches('\"').to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,8 +266,33 @@ fn compile_markdown (
 
                                         match key {
                                             "title" => {
-                                                let processed_title = val.trim().trim_matches('\'').trim_matches('\"').to_string();
-                                                frontmatter.title = Some(processed_title);
+                                                let mut chars = val.chars();
+
+                                                // Get the first character
+                                                let first_char = chars.next(); // Returns an Option<char>
+                                            
+                                                // Iterate to the last character
+                                                let mut last_char = None;
+                                                while let Some(c) = chars.next() {
+                                                    last_char = Some(c);
+                                                }
+                                                if first_char == "\'".chars().next() || first_char == "\'".chars().next() {
+                                                    if last_char == "\"".chars().next() || last_char == "\"".chars().next() {
+                                                        if first_char == last_char {
+                                                            let mut modified_string: String = chars.collect();
+                                                            // Remove the first character
+                                                            modified_string.remove(0);
+
+                                                            // Remove the last character
+                                                            modified_string.pop();
+                                                            frontmatter.title = modified_string;
+                                                        }
+
+                                                        
+                                                    }
+                                                }
+                                               
+                                                
                                             },
                                             "description" => {
                                                 frontmatter.description = Some(val.trim().trim_matches('\"').to_string())
@@ -278,30 +303,7 @@ fn compile_markdown (
                                                 if val.trim().trim_matches('\"') == "true" {
                                                     println!("DRAFT {}", path);
                                                     // Code to make it not compile
-                                                    let mut chars = val.chars();
-
-                                                    // Get the first character
-                                                    let first_char = chars.next(); // Returns an Option<char>
-                                                
-                                                    // Iterate to the last character
-                                                    let mut last_char = None;
-                                                    while let Some(c) = chars.next() {
-                                                        last_char = Some(c);
-                                                    }
-                                                    if first_char == "\'".chars().next() || first_char == "\'".chars().next() {
-                                                        if last_char == "\"".chars().next() || last_char == "\"".chars().next() {
-                                                            if first_char == last_char {
-                                                                let mut modified_string: String = chars.collect();
-                                                                // Remove the first character
-                                                                modified_string.remove(0);
-
-                                                                // Remove the last character
-                                                                modified_string.pop();
-                                                            }
-
-                                                            
-                                                        }
-                                                    }
+                                                    
                                                 }
                                             },
                                             _ => (),


### PR DESCRIPTION
It removes all quotation marks at the beginning and end of the title (First ', then "). It does this to all frontmatter values.
E.g.
'""Testing"' => Testing
"'Testing'" => 'Testing'
"""Testing''' => Testing
'"'Testing"'" => 'Testing"'